### PR TITLE
Add python library paho-mqtt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN echo "**** install Python ****" && \
     pip3 install -U configparser  &&  \
     pip3 install -U requests  &&  \
     pip3 install -U robotframework-requests  &&  \
+    pip3 install -U paho-mqtt  &&  \
     apk add --no-cache py3-numpy
 
 ENTRYPOINT ["sh", "/usr/local/bin/robot-entrypoint.sh"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ RESTinstance
 configparser
 requests
 numpy
+paho-mqtt

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="edgex-taf-common",
-    version="0.0.1",
+    version="0.0.2",
     description="EdgeX Test Automation Framework Common ",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
1. Added python library paho-mqtt.
2. Updated version to 0.0.2
Signed-off-by: Cherry Wang <cherry@iotechsys.com>