### PR TITLE
feat: Add lib to collect system metrics for scalability test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN echo "**** install Python ****" && \
     pip3 install -U requests  &&  \
     pip3 install -U robotframework-requests  &&  \
     pip3 install -U paho-mqtt  &&  \
-    apk add --no-cache py3-numpy
+    apk add --no-cache py3-numpy && \
+    apk add --no-cache py3-psutil
 
 ENTRYPOINT ["sh", "/usr/local/bin/robot-entrypoint.sh"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ configparser
 requests
 numpy
 paho-mqtt
+docker
+psutil


### PR DESCRIPTION
Fix #18
According to the Modbus scalability test case edgexfoundry/edgex-taf#137, add lib to collect system metrics.