### PR TITLE
feat: add default suite setup/teardown for TAF log files

### DIFF
--- a/TUC/setup/SetupTeardown.py
+++ b/TUC/setup/SetupTeardown.py
@@ -1,0 +1,95 @@
+"""
+@copyright Copyright (C) 2025 IOTech Ltd
+@license SPDX-License-Identifier: Apache-2.0
+
+@package TUC.setup
+
+@file SetupTeardown.py
+
+@description
+    This file includes default setup and teardown routines called by robot to setup and teardown
+    the test suite.
+"""
+
+import sys
+import logging
+
+from TUC.report.ColorLog import ColorLog
+from TUC.trigger import ARTIFACTS_LOGS_DIR
+from TUC.data.SettingsInfo import SettingsInfo
+
+_STANZA = "*" * 50
+_SML_STANZA = "*" * 12
+
+
+def suite_setup(suite_name, logfile=None, loglevel="DEBUG"):
+    """
+    Suite_Setup sets up the test cases
+
+    Gets the log and config and puts them in the SettingsInfo object
+
+    The API between Robot and this script is that this script
+    return True or False.  The policy here is catch exceptions,
+    log them, and return False to Robot.
+
+    @param suite_name:   required suite name
+    @param logfile:   sets logfile, if empty, sets to {ARTIFACTS_LOGS_DIR}/{suite_name}.log
+    @param loglevel:  sets loglevel
+    @return: True if all code was executed successfully.
+    """
+    tc_name = "Suite Setup:"
+
+    # Setup logger
+    logging.getLogger().setLevel(loglevel)
+    if not logfile:
+        logfile = f"{ARTIFACTS_LOGS_DIR}/{suite_name}.log"
+    test_log = ColorLog(
+        filename=logfile, lvl=loglevel, logName=suite_name, useBackGroundLogger=False
+    )
+
+    loglvl = logging.getLogger().getEffectiveLevel()
+    _print_log_header(test_log)
+    test_log.info(
+        "{} Logging started, level: {}".format(tc_name, logging.getLevelName(loglvl))
+    )
+    test_log.info("{} python version: {}".format(tc_name, sys.version))
+    test_log.info("Suite Name: {}".format(suite_name))
+    SettingsInfo().add_name("TestLog", test_log)
+    return True
+
+
+def suite_teardown():
+    """
+    Teardown the suite:
+        print footer
+        close the log file
+
+    @retval True returned to robot
+    """
+    testLog = SettingsInfo().TestLog
+    testLog.info("Suite Teardown")
+
+    _print_log_footer(testLog)
+    testLog.close()
+
+    return True
+
+
+def _print_log_header(log):
+    """
+    print log header
+    @param     log     Logger object
+    """
+    log.info("{}".format(_STANZA))
+    log.info("{}".format(_STANZA))
+    log.info("{}{}{}".format(_SML_STANZA, "  TEST RUN START  ", _SML_STANZA))
+
+
+def _print_log_footer(log):
+    """
+    print log footer
+    @param     log     Logger object
+    """
+    log.info("{}{}{}".format(_SML_STANZA, "    TEST RUN END  ", _SML_STANZA))
+    log.info("{}".format(_STANZA))
+    log.info("{}".format(_STANZA))

--- a/TUC/trigger.py
+++ b/TUC/trigger.py
@@ -238,8 +238,6 @@ def get_kwargs(args):
 
     if args.name:
         kwargs["name"] = args.name
-    elif args.configDir:
-        kwargs["name"] = args.configDir
 
     if args.include:
         kwargs["include"] = args.include


### PR DESCRIPTION
Also remove setting suite name with config dir. Instead, if name is not given, use robot default suite name, which is the file path.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->