### PR TITLE
fix: update report cleanup files

### DIFF
--- a/TUC/trigger.py
+++ b/TUC/trigger.py
@@ -192,7 +192,8 @@ def remove_old_report_folder(dir):
         logging.debug(
             "Delete obsolete report files under '{}'".format(ARTIFACTS_REPORTS_DIR)
         )
-        remove_files(ARTIFACTS_REPORTS_DIR)
+        remove_files(ARTIFACTS_REPORTS_DIR, "*.xml")
+        remove_files(ARTIFACTS_REPORTS_DIR, "*.html")
     elif os.path.isdir(full_dir):
         logging.debug("Delete obsolete report folder: {}".format(dir))
         shutil.rmtree(full_dir)


### PR DESCRIPTION
do not remove the whole `ARTIFACTS_REPORTS_DIR` folder, only xml and html files in the `ARTIFACTS_REPORTS_DIR`

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->